### PR TITLE
level6-module0: Fix CarTest mocking

### DIFF
--- a/Level6_Module0/src/test/java/_07_intro_to_mocking/models/CarTest.java
+++ b/Level6_Module0/src/test/java/_07_intro_to_mocking/models/CarTest.java
@@ -50,7 +50,7 @@ class CarTest {
         when(gasTank.fill(octane)).thenReturn(true);
 
         //when
-        boolean actualFilled = gasTank.fill(octane);
+        boolean actualFilled = car.fillTank(octane);
 
         //then
         assertEquals(expectedFilled, actualFilled);
@@ -65,7 +65,7 @@ class CarTest {
         when(gasTank.getFuelLevel()).thenReturn(expectedFuelLevelGallons);
 
         //when
-        double actualFuelLevelGallons = gasTank.getFuelLevel();
+        double actualFuelLevelGallons = car.getFuelLevel();
 
         //then
         assertEquals(expectedFuelLevelGallons, actualFuelLevelGallons);


### PR DESCRIPTION
The test should be testing the car.fillTank() and car.getFuelLevel() methods, not the methods of the mocked GasTank.